### PR TITLE
kubernetes-intro

### DIFF
--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: jndogan/kube-intro-hipstershop:latest
+    name: frontend
+    env:
+      - {name: PRODUCT_CATALOG_SERVICE_ADDR, value: "productcatalogservice:3550"}
+      - {name: CURRENCY_SERVICE_ADDR, value: "currencyservice:7000"}
+      - {name: CART_SERVICE_ADDR, value: "cartservice:7070"}
+      - {name: RECOMMENDATION_SERVICE_ADDR, value: "recommendationservice:8080"}
+      - {name: SHIPPING_SERVICE_ADDR, value: "shippingservice:50051"}
+      - {name: CHECKOUT_SERVICE_ADDR, value: "checkoutservice:5050"}
+      - {name: AD_SERVICE_ADDR, value: "adservice:9555"}
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: jndogan/kube-intro-hipstershop:latest
+    name: frontend
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  containers:
+    - name: web
+      image: jndogan/web:1.0.0
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  initContainers:
+    - name: init-index-page
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx:1.18-alpine
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+RUN mkdir /app \
+    && echo '<html><head><meta charset="UTF-8"></head><body>¯\_(ツ)_/¯</body></html>' > /app/index.html 
+
+USER 1001
+EXPOSE 8000

--- a/kubernetes-intro/web/nginx.conf
+++ b/kubernetes-intro/web/nginx.conf
@@ -1,0 +1,42 @@
+
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /tmp/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    proxy_temp_path /tmp/proxy_temp;
+    scgi_temp_path /tmp/scgi_temp;
+    client_body_temp_path /tmp/client_body;
+
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+    
+    server {
+        listen 8000;
+        root /app;
+    }
+}


### PR DESCRIPTION
# Выполнено ДЗ №1

- [x] Основное ДЗ
- [x] Задание со *

## В процессе сделано:

- Установлен minikube
- Установлен kubectl
- Создан Dockerfile c nginx, упакован в образ и опубликован в репозитории DockerHub
- Создан манифест web-pod.yaml для разворачивания пода с опубликованным образом nginx
- Создан образ c frontend компонентом онлайн-сервиса HipsterShop и опубликован в репозитории DockerHub
- Создан манифест frontend-pod.yaml для разворачивания пода с опубликованным образом HipsterShop frontend
- Создан манифсет с исправлением для запуска образа HipsterShop frontend. В описании Пода отсутствовали переменные среды окружения.
- Static Pod - это под, который разворачивается на ноде и находится под управлением кублета, при этом api-server создает зеркальный под для представления его в кластере, но не управляем им.
В VM minikube стоит кублет в конфигурации к запуску которого прописан путь к хранилищу static pod, где и лежат манифесты kube-apiserver, kube-controller-manager, kube-scheduler. То есть перечисленные компоненты управляются кублетом с ноды
1. Заходим в VM minikube
```bash
minikube ssh
```
2. Смотрим настройки кублета
```bash
# cat /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
[Unit]
Wants=docker.socket

[Service]
ExecStart=
ExecStart=/var/lib/minikube/binaries/v1.18.0/kubelet --authorization-mode=Webhook --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --cgroup-driver=systemd --client-ca-file=/var/lib/minikube/certs/ca.cr
t --cluster-domain=cluster.local --config=/var/lib/kubelet/config.yaml --container-runtime=docker --fail-swap-on=false --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.64.21 
--pod-manifest-path=/etc/kubernetes/manifests

[Install]
```
3. Смотрим манифесты static pod'ов
```bash
# ls /etc/kubernetes/manifests
etcd.yaml  kube-apiserver.yaml kube-controller-manager.yaml  kube-scheduler.yaml
```

## Как запустить проект:

- Под с nginx

```bash
minikube start
kubectl apply -f web-pod.yaml
kubectl port-forward --address 0.0.0.0 pod/web 8000:8000
```

- Под с HipsterShop frontend

```bash
minikube start
kubectl apply -f frontend-pod.yaml // frontend-pod-healthy.yaml для проверки исправленного решения
kubectl port-forward --address 0.0.0.0 pod/frontend 8080:8080
```

## Как проверить работоспособность:

- Для проверки запуска пода с nginx перейти по ссылке <http://localhost:8000>
- Для проверки запуска пода с HipsterShop frontend перейти по ссылке <http://localhost:8080>

## PR checklist:

- [x] Выставлен label с номером домашнего задания