### PR TITLE
Kubernetes Debug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "kubernetes-debug/kit/netperf-operator"]
+	path = kubernetes-debug/kit/netperf-operator
+	url = git@github.com:piontec/netperf-operator.git

--- a/kubernetes-debug/kit/iptables-tailer.yaml
+++ b/kubernetes-debug/kit/iptables-tailer.yaml
@@ -1,0 +1,45 @@
+---
+  apiVersion: "extensions/v1beta1"
+  kind: "DaemonSet"
+  metadata: 
+    name: "kube-iptables-tailer"
+    namespace: "kube-system"
+  spec: 
+    template:
+      metadata:
+        labels:
+          app: "kube-iptables-tailer"
+      spec: 
+        serviceAccountName: kube-iptables-tailer
+        containers: 
+          - name: "kube-iptables-tailer"
+            command:
+              - "/kube-iptables-tailer"
+              - "--log_dir=/my-service-logs" # change the output directory of service logs
+              - "--v=4" # enable V-leveled logging at this level
+            env: 
+              - name: "JOURNAL_DIRECTORY"
+                value: "/var/log/journal"
+              - name: "POD_IDENTIFIER"
+                value: "name"
+              # - name: "POD_IDENTIFIER_LABEL"
+              #   value: "netperf-type"
+              - name: "IPTABLES_LOG_PREFIX"
+                # log prefix defined in your iptables chains
+                value: "calico-packet:"
+            image: "virtualshuric/kube-iptables-tailer:8d4296a"
+            imagePullPolicy: Always
+            volumeMounts: 
+              - name: "iptables-logs"
+                mountPath: "/var/log/"
+                readOnly: true
+              - name: "service-logs"
+                mountPath: "/my-service-logs"
+
+        volumes:
+          - name: "iptables-logs"
+            hostPath: 
+              # absolute path of the directory containing iptables log file on your host
+              path: "/var/log"
+          - name: "service-logs"
+            emptyDir: {}

--- a/kubernetes-debug/kit/kit-clusterrole.yaml
+++ b/kubernetes-debug/kit/kit-clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-iptables-tailer
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs:     ["list","get","watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs:     ["patch","create"]

--- a/kubernetes-debug/kit/kit-clusterrolebinding.yaml
+++ b/kubernetes-debug/kit/kit-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-iptables-tailer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-iptables-tailer
+subjects:
+- kind: ServiceAccount
+  name: kube-iptables-tailer
+  namespace: kube-system

--- a/kubernetes-debug/kit/kit-serviceaccount.yaml
+++ b/kubernetes-debug/kit/kit-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-iptables-tailer
+  namespace: kube-system

--- a/kubernetes-debug/kit/netperf-calico-policy.yaml
+++ b/kubernetes-debug/kit/netperf-calico-policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: netperf-calico-policy
+  labels:
+spec:
+  order: 10
+  selector: app == "netperf-operator"
+  ingress:
+    - action: Allow
+      source:
+        selector: app == "netperf-operator"
+    - action: Log
+    - action: Deny
+  egress:
+    - action: Allow
+      destination:
+        selector: app == "netperf-operator"
+    - action: Log
+    - action: Deny

--- a/kubernetes-debug/strace/agent-daemonset.yaml
+++ b/kubernetes-debug/strace/agent-daemonset.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: debug-agent
+  name: debug-agent
+spec:
+  selector:
+    matchLabels:
+      app: debug-agent
+  template:
+    metadata:
+      labels:
+        app: debug-agent
+    spec:
+      containers:
+      - image: aylei/debug-agent:0.0.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10027
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: debug-agent
+        ports:
+        - containerPort: 10027
+          hostPort: 10027
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: docker
+          mountPath: "/var/run/docker.sock"
+      hostNetwork: true
+      volumes:
+      - name: docker
+        hostPath:
+          path: /var/run/docker.sock
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 5
+    type: RollingUpdate


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со * Исправить сетевую политику Netperf
 - [x] Задание со * Выводить в логах имена подов

## В процессе сделано:
## Kubectl Debug

Установим `kubectl debug`

```bash
% brew install aylei/tap/kubectl-debug
```

Вкатываем daemonset

```bash
% kubectl apply -f kubernetes-debug/strace/agent-daemonset.yaml
```

Вкатим под для тестов

```bash
% kubectl create deployment nginx --image=nginx:latest
```

Запускаем

```bash
% kubectl debug -n default --agentless=false nginx-76546c5b7d-n9xkr
Forwarding from 127.0.0.1:10027 -> 10027
Forwarding from [::1]:10027 -> 10027
Handling connection for 10027
                             pulling image docker.io/nicolaka/netshoot:latest... 
latest: Pulling from nicolaka/netshoot
cbdbe7a5bc2a: Pull complete 
fa7edde5704a: Pull complete 
d142e371ed28: Pull complete 
7bc9cb006bce: Pull complete 
a4d2c327d444: Pull complete 
428e55c983a8: Pull complete 
1209022df24d: Pull complete 
b74093e72c31: Pull complete 
Digest: sha256:04786602e5a9463f40da65aea06fe5a825425c7df53b307daa21f828cfe40bf8
Status: Downloaded newer image for nicolaka/netshoot:latest
starting debug container...
container created, open tty...
bash-5.0# 
```

Пробуем использовать `strace` и получаем ошибку

```bash
bash-5.0# strace -p 28
strace: attach: ptrace(PTRACE_SEIZE, 28): Operation not permitted
```

Обновим версию debug agent'а на свежую, так как проблема была решена в новых [версиях](https://github.com/aylei/kubectl-debug/commit/90ee6bf28325789b60d2e7fff78634c75fc90e8d)

```bash
% kubectl delete -f kubernetes-debug/strace/agent-daemonset.yaml
% kubectl apply -f https://raw.githubusercontent.com/aylei/kubectl-debug/master/scripts/agent_daemonset.yml
```

Попробуем вызвать `localhost` и посмотреть результат

```bash
% kubectl exec -it pod/nginx-76546c5b7d-n9xkr -- curl 127.0.0.1
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>
```

```bash
bash-5.0# strace -p 28
strace: Process 28 attached
epoll_wait(10, 



[{EPOLLIN, {u32=4146225168, u64=140002900205584}}], 512, -1) = 1
accept4(7, {sa_family=AF_INET, sin_port=htons(56920), sin_addr=inet_addr("127.0.0.1")}, [112->16], SOCK_NONBLOCK) = 4
epoll_ctl(10, EPOLL_CTL_ADD, 4, {EPOLLIN|EPOLLRDHUP|EPOLLET, {u32=4146225864, u64=140002900206280}}) = 0
epoll_wait(10, [{EPOLLIN, {u32=4146225864, u64=140002900206280}}], 512, 60000) = 1
recvfrom(4, "GET / HTTP/1.1\r\nHost: 127.0.0.1\r"..., 1024, 0, NULL, NULL) = 73
stat("/usr/share/nginx/html/index.html", {st_mode=S_IFREG|0644, st_size=612, ...}) = 0
openat(AT_FDCWD, "/usr/share/nginx/html/index.html", O_RDONLY|O_NONBLOCK) = 13
fstat(13, {st_mode=S_IFREG|0644, st_size=612, ...}) = 0
writev(4, [{iov_base="HTTP/1.1 200 OK\r\nServer: nginx/1"..., iov_len=238}], 1) = 238
sendfile(4, 13, [0] => [612], 612)      = 612
write(6, "127.0.0.1 - - [02/Aug/2020:14:31"..., 90) = 90
close(13)                               = 0
setsockopt(4, SOL_TCP, TCP_NODELAY, [1], 4) = 0
epoll_wait(10, [{EPOLLIN|EPOLLRDHUP, {u32=4146225864, u64=140002900206280}}], 512, 65000) = 1
recvfrom(4, "", 1024, 0, NULL, NULL)    = 0
close(4)                                = 0
epoll_wait(10, 
```

## Kit

### Подготовка

Для начала установим CALICO. Для этого обновим манифест `terraform` в репозитории https://gitlab.com/dmitriye/microservices-demo-cluster

```hcl
  ...
    addons_config {
        ...
        network_policy_config {
            disabled = false
        }
        ...
    }

    network_policy {
        enabled = true
        provider = "CALICO"
    }
  ...
```

```bash
% git submodule add git@github.com:piontec/netperf-operator.git
```

### iptables-tailer

Установка

```bash
% kubectl apply -f kubernetes-debug/kit/netperf-operator/deploy/crd.yaml
% kubectl apply -f kubernetes-debug/kit/netperf-operator/deploy/rbac.yaml
% kubectl apply -f kubernetes-debug/kit/netperf-operator/deploy/operator.yaml
```

Запуск теста

```bash
% kubectl apply -f kubernetes-debug/kit/netperf-operator/deploy/cr.yaml

% kubectl describe netperf.app.example.com/example
Name:         example
Namespace:    default
Labels:       <none>
Annotations:  kubectl.kubernetes.io/last-applied-configuration:
                {"apiVersion":"app.example.com/v1alpha1","kind":"Netperf","metadata":{"annotations":{},"name":"example","namespace":"default"}}
API Version:  app.example.com/v1alpha1
Kind:         Netperf
Metadata:
  Creation Timestamp:  2020-08-02T15:06:08Z
  Generation:          4
  Resource Version:    924002
  Self Link:           /apis/app.example.com/v1alpha1/namespaces/default/netperfs/example
  UID:                 18a26e8d-08b4-4e5d-ae3b-2648000f8c67
Spec:
  Client Node:  
  Server Node:  
Status:
  Client Pod:          netperf-client-2648000f8c67
  Server Pod:          netperf-server-2648000f8c67
  Speed Bits Per Sec:  5889.93
  Status:              Done
Events:                <none>
```

Добавим политику для CALICO

```bash
% kubectl apply -f kubernetes-debug/kit/netperf-calico-policy.yaml
```

Устанавливаем iptables-tailer

```bash
% kubectl apply -f kubernetes-debug/kit/kit-clusterrole.yaml
% kubectl apply -f kubernetes-debug/kit/kit-clusterrolebinding.yaml
% kubectl apply -f kubernetes-debug/kit/kit-serviceaccount.yaml
% kubectl apply -f kubernetes-debug/kit/iptables-tailer.yaml

...

% kubectl -n kube-system get all -l app=kube-iptables-tailer
NAME                             READY   STATUS    RESTARTS   AGE
pod/kube-iptables-tailer-842zd   1/1     Running   0          3m35s
pod/kube-iptables-tailer-k6bbq   1/1     Running   0          3m35s
pod/kube-iptables-tailer-qn9hw   1/1     Running   0          3m35s
pod/kube-iptables-tailer-thrwq   1/1     Running   0          3m35s

NAME                                  DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/kube-iptables-tailer   4         4         4       4            4           <none>          4m17s
```

Теперь попробуем запустить наш тест по новой

```bash
% kubectl delete -f kubernetes-debug/kit/netperf-operator/deploy/cr.yaml
% kubectl apply -f kubernetes-debug/kit/netperf-operator/deploy/cr.yaml
% kubectl describe netperf.app.example.com/example
Name:         example
Namespace:    default
Labels:       <none>
Annotations:  kubectl.kubernetes.io/last-applied-configuration:
                {"apiVersion":"app.example.com/v1alpha1","kind":"Netperf","metadata":{"annotations":{},"name":"example","namespace":"default"}}
API Version:  app.example.com/v1alpha1
Kind:         Netperf
Metadata:
  Creation Timestamp:  2020-08-03T03:47:13Z
  Generation:          3
  Resource Version:    1139186
  Self Link:           /apis/app.example.com/v1alpha1/namespaces/default/netperfs/example
  UID:                 b1783b48-69dd-46e3-8d1a-284327ebed06
Spec:
  Client Node:  
  Server Node:  
Status:
  Client Pod:          netperf-client-284327ebed06
  Server Pod:          netperf-server-284327ebed06
  Speed Bits Per Sec:  0
  Status:              Started test
Events:                <none>


% kubectl describe pod --selector=app=netperf-operator

Events:
  Type     Reason      Age    From                                                Message
  ----     ------      ----   ----                                                -------
  Normal   Scheduled   3m16s  default-scheduler                                   Successfully assigned default/netperf-server-284327ebed06 to gke-my-cluster-worker-nodes-3d8cd663-48jl
  Normal   Pulling     3m15s  kubelet, gke-my-cluster-worker-nodes-3d8cd663-48jl  Pulling image "tailoredcloud/netperf:v2.7"
  Normal   Pulled      3m13s  kubelet, gke-my-cluster-worker-nodes-3d8cd663-48jl  Successfully pulled image "tailoredcloud/netperf:v2.7"
  Normal   Created     3m13s  kubelet, gke-my-cluster-worker-nodes-3d8cd663-48jl  Created container netperf-server-284327ebed06
  Normal   Started     3m13s  kubelet, gke-my-cluster-worker-nodes-3d8cd663-48jl  Started container netperf-server-284327ebed06
  Warning  PacketDrop  3m9s   kube-iptables-tailer                                Packet dropped when receiving traffic from 10.12.0.8
  Warning  PacketDrop  49s    kube-iptables-tailer                                Packet dropped when receiving traffic from client (10.12.0.8)
```

## Поправьте манифест DaemonSet из репозитория, чтобы в логах отображались имена Podов, а не их IP-адреса

```yaml
  ...
  - name: "POD_IDENTIFIER"
    value: "name"
  ...
```

```bash
% kubectl apply -f kubernetes-debug/kit/iptables-tailer.yaml
% kubectl -n kube-system delete pod -l app=kube-iptables-tailer

% kubectl delete -f kubernetes-debug/kit/netperf-operator/deploy/cr.yaml
% kubectl apply -f kubernetes-debug/kit/netperf-operator/deploy/cr.yaml

% kubectl describe pod --selector=app=netperf-operator

Events:
  Type     Reason      Age                From                                                Message
  ----     ------      ----               ----                                                -------
  Normal   Scheduled   15m                default-scheduler                                   Successfully assigned default/netperf-server-96a32e71f629 to gke-my-cluster-worker-nodes-3d8cd663-48jl
  Normal   Pulled      15m                kubelet, gke-my-cluster-worker-nodes-3d8cd663-48jl  Container image "tailoredcloud/netperf:v2.7" already present on machine
  Normal   Created     15m                kubelet, gke-my-cluster-worker-nodes-3d8cd663-48jl  Created container netperf-server-96a32e71f629
  Normal   Started     15m                kubelet, gke-my-cluster-worker-nodes-3d8cd663-48jl  Started container netperf-server-96a32e71f629
  Warning  PacketDrop  15m                kube-iptables-tailer                                Packet dropped when receiving traffic from 10.12.0.12
  Warning  PacketDrop  81s (x4 over 13m)  kube-iptables-tailer                                Packet dropped when receiving traffic from netperf-client-96a32e71f629 (10.12.0.12)
```


## Исправьте ошибку в нашей сетевой политике, чтобы Netperf снова начал работать

Меняем `source` и `destination` селекторы, чтобы мог ходить трафик

```yaml
  ...
  source:
    selector: app == "netperf-operator"
  ...
  destination:
    selector: app == "netperf-operator"
```

И тест снова становится успешным

```bash
% kubectl apply -f kubernetes-debug/kit/netperf-calico-policy.yaml
% kubectl apply -f kubernetes-debug/kit/netperf-operator/deploy/cr.yaml
% kubectl describe netperf.app.example.com/example
Name:         example
Namespace:    default
Labels:       <none>
Annotations:  kubectl.kubernetes.io/last-applied-configuration:
                {"apiVersion":"app.example.com/v1alpha1","kind":"Netperf","metadata":{"annotations":{},"name":"example","namespace":"default"}}
API Version:  app.example.com/v1alpha1
Kind:         Netperf
Metadata:
  Creation Timestamp:  2020-08-03T04:37:26Z
  Generation:          4
  Resource Version:    1153510
  Self Link:           /apis/app.example.com/v1alpha1/namespaces/default/netperfs/example
  UID:                 1f137ce1-db1a-4fac-9d2d-c9d527f42899
Spec:
  Client Node:  
  Server Node:  
Status:
  Client Pod:          netperf-client-c9d527f42899
  Server Pod:          netperf-server-c9d527f42899
  Speed Bits Per Sec:  7869.43
  Status:              Done
Events:                <none>
```

## PR checklist:
 - [x] Выставлен label с темой домашнего задания