### PR TITLE
Kubernetes Storage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "kubernetes-debug/kit/netperf-operator"]
 	path = kubernetes-debug/kit/netperf-operator
 	url = git@github.com:piontec/netperf-operator.git
+[submodule "kubernetes-storage/csi-driver-host-path"]
+	path = kubernetes-storage/csi-driver-host-path
+	url = git@github.com:kubernetes-csi/csi-driver-host-path.git

--- a/kubernetes-storage/hw/storage-pod.yaml
+++ b/kubernetes-storage/hw/storage-pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: storage-pod
+spec:
+  containers:
+    - image: gcr.io/google_containers/busybox
+      command: ["/bin/sh", "-c"]
+      args: [ "tail -f /dev/null" ]
+      name: busybox
+      volumeMounts:
+        - name: storage
+          mountPath: /data
+  volumes:
+    - name: storage
+      persistentVolumeClaim:
+        claimName: storage-pvc

--- a/kubernetes-storage/hw/storage-pvc-restore.yaml
+++ b/kubernetes-storage/hw/storage-pvc-restore.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-pvc
+spec:
+  storageClassName: csi-hostpath-sc
+  dataSource:
+    name: storage-snapshot
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes-storage/hw/storage-pvc.yaml
+++ b/kubernetes-storage/hw/storage-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-pvc
+spec:
+  storageClassName: csi-hostpath-sc
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes-storage/hw/storage-snapshot.yaml
+++ b/kubernetes-storage/hw/storage-snapshot.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshot
+metadata:
+  name: storage-snapshot
+spec:
+  volumeSnapshotClassName: csi-hostpath-snapclass
+  source:
+    persistentVolumeClaimName: storage-pvc

--- a/kubernetes-storage/kind-config.yaml
+++ b/kubernetes-storage/kind-config.yaml
@@ -1,0 +1,5 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+  - role: control-plane
+  - role: worker


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:

## Подготовка

Поднимаем кластер

```bash
% kind create cluster --config ./kubernetes-storage/kind-config.yaml
```

Устанавливаем CSI Host Path Driver & External Snapshooter

```bash
# Snapshooter CRDs
% kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v2.1.1/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
% kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v2.1.1/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
% kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v2.1.1/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml

# Snapshooter Controller
% kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v2.1.1/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
% kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v2.1.1/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml

# CSI Host Path Driver
% zsh kubernetes-storage/csi-driver-host-path/deploy/kubernetes-1.18/deploy.sh
```

## Задание

Создадим `Storage Class` с именем `csi-hostpath-sc` из набора примеров

```bash
% kubectl apply -f kubernetes-storage/csi-driver-host-path/examples/csi-storageclass.yaml
```

Создадим `PVC` по нашему `Storage Class`'у

```bash
% kubectl apply -f kubernetes-storage/hw/storage-pvc.yaml
persistentvolumeclaim/storage-pvc created

% kubectl get pvc
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
storage-pvc   Bound    pvc-bf9012c8-8a4e-4338-9fb9-8593fbf8c073   1Gi        RWO            csi-hostpath-sc   8s

% kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                 STORAGECLASS      REASON   AGE
pvc-bf9012c8-8a4e-4338-9fb9-8593fbf8c073   1Gi        RWO            Delete           Bound    default/storage-pvc   csi-hostpath-sc            8s
```

Поднимем `Pod` с `PVC`

```bash
% kubectl apply -f kubernetes-storage/hw/storage-pod.yaml

% kubectl describe pod/storage-pod
Events:
  Type    Reason                  Age   From                     Message
  ----    ------                  ----  ----                     -------
  Normal  Scheduled               76s   default-scheduler        Successfully assigned default/storage-pod to kind-worker
  Normal  SuccessfulAttachVolume  75s   attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-bf9012c8-8a4e-4338-9fb9-8593fbf8c073"
```

Проверим запись

```bash
% kubectl exec -it pod/storage-pod -- touch /data/some-data.txt

% kubectl exec -it pod/storage-pod -- ls -la /data
total 8
drwxr-xr-x    2 root     root          4096 Aug  6 16:37 .
drwxr-xr-x    1 root     root          4096 Aug  6 16:35 ..
-rw-r--r--    1 root     root             0 Aug  6 16:37 some-data.txt
```

## Работа со снапшотами

Создадим снапшот

```bash
% kubectl apply -f kubernetes-storage/hw/storage-snapshot.yaml
```

Проверим его создание

```bash
% kubectl get VolumeSnapshotContent
NAME                                               READYTOUSE   RESTORESIZE   DELETIONPOLICY   DRIVER                VOLUMESNAPSHOTCLASS      VOLUMESNAPSHOT     AGE
snapcontent-e0d8eb5c-43b6-484d-8c69-f6345a2fde91   true         1073741824    Delete           hostpath.csi.k8s.io   csi-hostpath-snapclass   storage-snapshot   90s
```

Удаляем `PVC` & `POD`

```bash
% kubectl delete -f kubernetes-storage/hw/storage-pod.yaml
% kubectl delete -f kubernetes-storage/hw/storage-pvc.yaml
```

Пробуем восстановить из снапшота

```bash
% kubectl apply -f kubernetes-storage/hw/storage-pvc-restore.yaml
% kubectl apply -f kubernetes-storage/hw/storage-pod.yaml
```

Проверяем данные

```bash
% kubectl exec -it pod/storage-pod -- ls -la /data
total 8
drwxr-xr-x    2 root     root          4096 Aug  6 17:08 .
drwxr-xr-x    1 root     root          4096 Aug  6 17:08 ..
-rw-r--r--    1 root     root             0 Aug  6 16:37 some-data.txt
```

## PR checklist:
 - [x] Выставлен label с темой домашнего задания