### PR TITLE
Kubernetes Production Clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __tmp
+kubernetes-production-clusters/inventory/my-cluster/credentials

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "kubernetes-storage/csi-driver-host-path"]
 	path = kubernetes-storage/csi-driver-host-path
 	url = git@github.com:kubernetes-csi/csi-driver-host-path.git
+[submodule "kubernetes-production-clusters/kubespray"]
+	path = kubernetes-production-clusters/kubespray
+	url = git@github.com:kubernetes-sigs/kubespray.git

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/all.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/all.yml
@@ -1,0 +1,98 @@
+---
+## Directory where etcd data stored
+etcd_data_dir: /var/lib/etcd
+
+## Experimental kubeadm etcd deployment mode. Available only for new deployment
+etcd_kubeadm_enabled: false
+
+## Directory where the binaries will be installed
+bin_dir: /usr/local/bin
+
+## The access_ip variable is used to define how other nodes should access
+## the node.  This is used in flannel to allow other flannel nodes to see
+## this node for example.  The access_ip is really useful AWS and Google
+## environments where the nodes are accessed remotely by the "public" ip,
+## but don't know about that address themselves.
+# access_ip: 1.1.1.1
+
+
+## External LB example config
+## apiserver_loadbalancer_domain_name: "elb.some.domain"
+# loadbalancer_apiserver:
+#   address: 1.2.3.4
+#   port: 1234
+
+## Internal loadbalancers for apiservers
+# loadbalancer_apiserver_localhost: true
+# valid options are "nginx" or "haproxy"
+# loadbalancer_apiserver_type: nginx  # valid values "nginx" or "haproxy"
+
+## Local loadbalancer should use this port
+## And must be set port 6443
+loadbalancer_apiserver_port: 6443
+
+## If loadbalancer_apiserver_healthcheck_port variable defined, enables proxy liveness check for nginx.
+loadbalancer_apiserver_healthcheck_port: 8081
+
+### OTHER OPTIONAL VARIABLES
+## For some things, kubelet needs to load kernel modules.  For example, dynamic kernel services are needed
+## for mounting persistent volumes into containers.  These may not be loaded by preinstall kubernetes
+## processes.  For example, ceph and rbd backed volumes.  Set to true to allow kubelet to load kernel
+## modules.
+# kubelet_load_modules: false
+
+## Upstream dns servers
+# upstream_dns_servers:
+#   - 8.8.8.8
+#   - 8.8.4.4
+
+## There are some changes specific to the cloud providers
+## for instance we need to encapsulate packets with some network plugins
+## If set the possible values are either 'gce', 'aws', 'azure', 'openstack', 'vsphere', 'oci', or 'external'
+## When openstack is used make sure to source in the openstack credentials
+## like you would do when using openstack-client before starting the playbook.
+# cloud_provider:
+
+## When cloud_provider is set to 'external', you can set the cloud controller to deploy
+## Supported cloud controllers are: 'openstack' and 'vsphere'
+## When openstack or vsphere are used make sure to source in the required fields
+# external_cloud_provider:
+
+## Set these proxy values in order to update package manager and docker daemon to use proxies
+# http_proxy: ""
+# https_proxy: ""
+
+## Refer to roles/kubespray-defaults/defaults/main.yml before modifying no_proxy
+# no_proxy: ""
+
+## Some problems may occur when downloading files over https proxy due to ansible bug
+## https://github.com/ansible/ansible/issues/32750. Set this variable to False to disable
+## SSL validation of get_url module. Note that kubespray will still be performing checksum validation.
+# download_validate_certs: False
+
+## If you need exclude all cluster nodes from proxy and other resources, add other resources here.
+# additional_no_proxy: ""
+
+## Certificate Management
+## This setting determines whether certs are generated via scripts.
+## Chose 'none' if you provide your own certificates.
+## Option is  "script", "none"
+## note: vault is removed
+# cert_management: script
+
+## Set to true to allow pre-checks to fail and continue deployment
+# ignore_assert_errors: false
+
+## The read-only port for the Kubelet to serve on with no authentication/authorization. Uncomment to enable.
+# kube_read_only_port: 10255
+
+## Set true to download and cache container
+# download_container: true
+
+## Deploy container engine
+# Set false if you want to deploy container engine manually.
+# deploy_container_engine: true
+
+## Set Pypi repo and cert accordingly
+# pyrepo_index: https://pypi.example.com/simple
+# pyrepo_cert: /etc/ssl/certs/ca-certificates.crt

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/aws.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/aws.yml
@@ -1,0 +1,8 @@
+## To use AWS EBS CSI Driver to provision volumes, uncomment the first value
+## and configure the parameters below
+# aws_ebs_csi_enabled: true
+# aws_ebs_csi_enable_volume_scheduling: true
+# aws_ebs_csi_enable_volume_snapshot: false
+# aws_ebs_csi_enable_volume_resizing: false
+# aws_ebs_csi_controller_replicas: 1
+# aws_ebs_csi_plugin_image_tag: latest

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/azure.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/azure.yml
@@ -1,0 +1,37 @@
+## When azure is used, you need to also set the following variables.
+## see docs/azure.md for details on how to get these values
+
+# azure_cloud:
+# azure_tenant_id:
+# azure_subscription_id:
+# azure_aad_client_id:
+# azure_aad_client_secret:
+# azure_resource_group:
+# azure_location:
+# azure_subnet_name:
+# azure_security_group_name:
+# azure_vnet_name:
+# azure_vnet_resource_group:
+# azure_route_table_name:
+# supported values are 'standard' or 'vmss'
+# azure_vmtype: standard
+
+## Azure Disk CSI credentials and parameters
+## see docs/azure-csi.md for details on how to get these values
+
+# azure_csi_tenant_id:
+# azure_csi_subscription_id:
+# azure_csi_aad_client_id:
+# azure_csi_aad_client_secret:
+# azure_csi_location:
+# azure_csi_resource_group:
+# azure_csi_vnet_name:
+# azure_csi_vnet_resource_group:
+# azure_csi_subnet_name:
+# azure_csi_security_group_name:
+# azure_csi_use_instance_metadata:
+
+## To enable Azure Disk CSI, uncomment below
+# azure_csi_enabled: true
+# azure_csi_controller_replicas: 1
+# azure_csi_plugin_image_tag: latest

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/containerd.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/containerd.yml
@@ -1,0 +1,15 @@
+---
+# Please see roles/container-engine/containerd/defaults/main.yml for more configuration options
+
+# containerd_config:
+#   grpc:
+#     max_recv_message_size: 16777216
+#     max_send_message_size: 16777216
+#   debug:
+#     level: ""
+#   registries:
+#     "docker.io": "https://registry-1.docker.io"
+#   max_container_log_line_size: -1
+#   metrics:
+#     address: ""
+#     grpc_histogram: false

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/coreos.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/coreos.yml
@@ -1,0 +1,2 @@
+## Does coreos need auto upgrade, default is true
+# coreos_auto_upgrade: true

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/docker.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/docker.yml
@@ -1,0 +1,54 @@
+---
+## Uncomment this if you want to force overlay/overlay2 as docker storage driver
+## Please note that overlay2 is only supported on newer kernels
+# docker_storage_options: -s overlay2
+
+## Enable docker_container_storage_setup, it will configure devicemapper driver on Centos7 or RedHat7.
+docker_container_storage_setup: false
+
+## It must be define a disk path for docker_container_storage_setup_devs.
+## Otherwise docker-storage-setup will be executed incorrectly.
+# docker_container_storage_setup_devs: /dev/vdb
+
+## Uncomment this if you have more than 3 nameservers, then we'll only use the first 3.
+docker_dns_servers_strict: false
+
+# Path used to store Docker data
+docker_daemon_graph: "/var/lib/docker"
+
+## Used to set docker daemon iptables options to true
+docker_iptables_enabled: "false"
+
+# Docker log options
+# Rotate container stderr/stdout logs at 50m and keep last 5
+docker_log_opts: "--log-opt max-size=50m --log-opt max-file=5"
+
+# define docker bin_dir
+docker_bin_dir: "/usr/bin"
+
+# keep docker packages after installation; speeds up repeated ansible provisioning runs when '1'
+# kubespray deletes the docker package on each run, so caching the package makes sense
+docker_rpm_keepcache: 0
+
+## An obvious use case is allowing insecure-registry access to self hosted registries.
+## Can be ipaddress and domain_name.
+## example define 172.19.16.11 or mirror.registry.io
+# docker_insecure_registries:
+#   - mirror.registry.io
+#   - 172.19.16.11
+
+## Add other registry,example China registry mirror.
+# docker_registry_mirrors:
+#   - https://registry.docker-cn.com
+#   - https://mirror.aliyuncs.com
+
+## If non-empty will override default system MountFlags value.
+## This option takes a mount propagation flag: shared, slave
+## or private, which control whether mounts in the file system
+## namespace set up for docker will receive or propagate mounts
+## and unmounts. Leave empty for system default
+# docker_mount_flags:
+
+## A string of extra options to pass to the docker daemon.
+## This string should be exactly as you wish it to appear.
+# docker_options: ""

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/gcp.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/gcp.yml
@@ -1,0 +1,10 @@
+## GCP compute Persistent Disk CSI Driver credentials and parameters
+## See docs/gcp-pd-csi.md for information about the implementation
+
+## Specify the path to the file containing the service account credentials
+# gcp_pd_csi_sa_cred_file: "/my/safe/credentials/directory/cloud-sa.json"
+
+## To enable GCP Persistent Disk CSI driver, uncomment below
+# gcp_pd_csi_enabled: true
+# gcp_pd_csi_controller_replicas: 1
+# gcp_pd_csi_driver_image_tag: "v0.7.0-gke.0"

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/oci.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/oci.yml
@@ -1,0 +1,28 @@
+## When Oracle Cloud Infrastructure is used, set these variables
+# oci_private_key:
+# oci_region_id:
+# oci_tenancy_id:
+# oci_user_id:
+# oci_user_fingerprint:
+# oci_compartment_id:
+# oci_vnc_id:
+# oci_subnet1_id:
+# oci_subnet2_id:
+## Override these default/optional behaviors if you wish
+# oci_security_list_management: All
+## If you would like the controller to manage specific lists per subnet. This is a mapping of subnet ocids to security list ocids. Below are examples.
+# oci_security_lists:
+#   ocid1.subnet.oc1.phx.aaaaaaaasa53hlkzk6nzksqfccegk2qnkxmphkblst3riclzs4rhwg7rg57q: ocid1.securitylist.oc1.iad.aaaaaaaaqti5jsfvyw6ejahh7r4okb2xbtuiuguswhs746mtahn72r7adt7q
+#   ocid1.subnet.oc1.phx.aaaaaaaahuxrgvs65iwdz7ekwgg3l5gyah7ww5klkwjcso74u3e4i64hvtvq: ocid1.securitylist.oc1.iad.aaaaaaaaqti5jsfvyw6ejahh7r4okb2xbtuiuguswhs746mtahn72r7adt7q
+## If oci_use_instance_principals is true, you do not need to set the region, tenancy, user, key, passphrase, or fingerprint
+# oci_use_instance_principals: false
+# oci_cloud_controller_version: 0.6.0
+## If you would like to control OCI query rate limits for the controller
+# oci_rate_limit:
+#   rate_limit_qps_read:
+#   rate_limit_qps_write:
+#   rate_limit_bucket_read:
+#   rate_limit_bucket_write:
+## Other optional variables
+# oci_cloud_controller_pull_source: (default iad.ocir.io/oracle/cloud-provider-oci)
+# oci_cloud_controller_pull_secret: (name of pull secret to use if you define your own mirror above)

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/openstack.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/openstack.yml
@@ -1,0 +1,44 @@
+## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (Fixed in 1.9: https://github.com/kubernetes/kubernetes/issues/50461)
+# openstack_blockstorage_version: "v1/v2/auto (default)"
+# openstack_blockstorage_ignore_volume_az: yes
+## When OpenStack is used, if LBaaSv2 is available you can enable it with the following 2 variables.
+# openstack_lbaas_enabled: True
+# openstack_lbaas_subnet_id: "Neutron subnet ID (not network ID) to create LBaaS VIP"
+## To enable automatic floating ip provisioning, specify a subnet.
+# openstack_lbaas_floating_network_id: "Neutron network ID (not subnet ID) to get floating IP from, disabled by default"
+## Override default LBaaS behavior
+# openstack_lbaas_use_octavia: False
+# openstack_lbaas_method: "ROUND_ROBIN"
+# openstack_lbaas_provider: "haproxy"
+# openstack_lbaas_create_monitor: "yes"
+# openstack_lbaas_monitor_delay: "1m"
+# openstack_lbaas_monitor_timeout: "30s"
+# openstack_lbaas_monitor_max_retries: "3"
+
+## Values for the external OpenStack Cloud Controller
+# external_openstack_lbaas_network_id: "Neutron network ID to create LBaaS VIP"
+# external_openstack_lbaas_subnet_id: "Neutron subnet ID to create LBaaS VIP"
+# external_openstack_lbaas_floating_network_id: "Neutron network ID to get floating IP from"
+# external_openstack_lbaas_floating_subnet_id: "Neutron subnet ID to get floating IP from"
+# external_openstack_lbaas_use_octavia: true
+# external_openstack_lbaas_method: "ROUND_ROBIN"
+# external_openstack_lbaas_create_monitor: false
+# external_openstack_lbaas_monitor_delay: "1m"
+# external_openstack_lbaas_monitor_timeout: "30s"
+# external_openstack_lbaas_monitor_max_retries: "3"
+# external_openstack_lbaas_manage_security_groups: false
+# external_openstack_lbaas_internal_lb: false
+# external_openstack_network_ipv6_disabled: false
+# external_openstack_network_internal_networks:
+#   - ""
+# external_openstack_network_public_networks:
+#   - ""
+# external_openstack_metadata_search_order: "configDrive,metadataService"
+
+## The tag of the external OpenStack Cloud Controller image
+# external_openstack_cloud_controller_image_tag: "latest"
+
+## To use Cinder CSI plugin to provision volumes set this value to true
+## Make sure to source in the openstack credentials
+# cinder_csi_enabled: true
+# cinder_csi_controller_replicas: 1

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/vsphere.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/all/vsphere.yml
@@ -1,0 +1,20 @@
+## Values for the external vSphere Cloud Provider
+# external_vsphere_vcenter_ip: "myvcenter.domain.com"
+# external_vsphere_vcenter_port: "443"
+# external_vsphere_insecure: "true"
+# external_vsphere_user: "administrator@vsphere.local"
+# external_vsphere_password: "K8s_admin"
+# external_vsphere_datacenter: "DATACENTER_name"
+# external_vsphere_kubernetes_cluster_id: "kubernetes-cluster-id"
+
+## Tags for the external vSphere Cloud Provider images
+# external_vsphere_cloud_controller_image_tag: "latest"
+# vsphere_syncer_image_tag: "v1.0.2"
+# vsphere_csi_attacher_image_tag: "v1.1.1"
+# vsphere_csi_controller: "v1.0.2"
+# vsphere_csi_liveness_probe_image_tag: "v1.1.0"
+# vsphere_csi_provisioner_image_tag: "v1.2.2"
+
+## To use vSphere CSI plugin to provision volumes set this value to true
+# vsphere_csi_enabled: true
+# vsphere_csi_controller_replicas: 1

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/etcd.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/etcd.yml
@@ -1,0 +1,22 @@
+---
+## Etcd auto compaction retention for mvcc key value store in hour
+# etcd_compaction_retention: 0
+
+## Set level of detail for etcd exported metrics, specify 'extensive' to include histogram metrics.
+# etcd_metrics: basic
+
+## Etcd is restricted by default to 512M on systems under 4GB RAM, 512MB is not enough for much more than testing.
+## Set this if your etcd nodes have less than 4GB but you want more RAM for etcd. Set to 0 for unrestricted RAM.
+# etcd_memory_limit: "512M"
+
+## Etcd has a default of 2G for its space quota. If you put a value in etcd_memory_limit which is less than
+## etcd_quota_backend_bytes, you may encounter out of memory terminations of the etcd cluster. Please check
+## etcd documentation for more information.
+# etcd_quota_backend_bytes: "2G"
+
+### ETCD: disable peer client cert authentication.
+# This affects ETCD_PEER_CLIENT_CERT_AUTH variable
+# etcd_peer_client_auth: true
+
+## Settings for etcd deployment type
+etcd_deployment_type: docker

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/addons.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/addons.yml
@@ -1,0 +1,145 @@
+---
+# Kubernetes dashboard
+# RBAC required. see docs/getting-started.md for access details.
+dashboard_enabled: true
+
+# Helm deployment
+helm_enabled: false
+
+# Registry deployment
+registry_enabled: false
+# registry_namespace: kube-system
+# registry_storage_class: ""
+# registry_disk_size: "10Gi"
+
+# Metrics Server deployment
+metrics_server_enabled: false
+# metrics_server_kubelet_insecure_tls: true
+# metrics_server_metric_resolution: 60s
+# metrics_server_kubelet_preferred_address_types: "InternalIP"
+
+# Rancher Local Path Provisioner
+local_path_provisioner_enabled: false
+# local_path_provisioner_namespace: "local-path-storage"
+# local_path_provisioner_storage_class: "local-path"
+# local_path_provisioner_reclaim_policy: Delete
+# local_path_provisioner_claim_root: /opt/local-path-provisioner/
+# local_path_provisioner_debug: false
+# local_path_provisioner_image_repo: "rancher/local-path-provisioner"
+# local_path_provisioner_image_tag: "v0.0.14"
+# local_path_provisioner_helper_image_repo: "busybox"
+# local_path_provisioner_helper_image_tag: "latest"
+
+# Local volume provisioner deployment
+local_volume_provisioner_enabled: false
+# local_volume_provisioner_namespace: kube-system
+# local_volume_provisioner_storage_classes:
+#   local-storage:
+#     host_dir: /mnt/disks
+#     mount_dir: /mnt/disks
+#     volume_mode: Filesystem
+#     fs_type: ext4
+#   fast-disks:
+#     host_dir: /mnt/fast-disks
+#     mount_dir: /mnt/fast-disks
+#     block_cleaner_command:
+#       - "/scripts/shred.sh"
+#       - "2"
+#     volume_mode: Filesystem
+#     fs_type: ext4
+
+# CephFS provisioner deployment
+cephfs_provisioner_enabled: false
+# cephfs_provisioner_namespace: "cephfs-provisioner"
+# cephfs_provisioner_cluster: ceph
+# cephfs_provisioner_monitors: "172.24.0.1:6789,172.24.0.2:6789,172.24.0.3:6789"
+# cephfs_provisioner_admin_id: admin
+# cephfs_provisioner_secret: secret
+# cephfs_provisioner_storage_class: cephfs
+# cephfs_provisioner_reclaim_policy: Delete
+# cephfs_provisioner_claim_root: /volumes
+# cephfs_provisioner_deterministic_names: true
+
+# RBD provisioner deployment
+rbd_provisioner_enabled: false
+# rbd_provisioner_namespace: rbd-provisioner
+# rbd_provisioner_replicas: 2
+# rbd_provisioner_monitors: "172.24.0.1:6789,172.24.0.2:6789,172.24.0.3:6789"
+# rbd_provisioner_pool: kube
+# rbd_provisioner_admin_id: admin
+# rbd_provisioner_secret_name: ceph-secret-admin
+# rbd_provisioner_secret: ceph-key-admin
+# rbd_provisioner_user_id: kube
+# rbd_provisioner_user_secret_name: ceph-secret-user
+# rbd_provisioner_user_secret: ceph-key-user
+# rbd_provisioner_user_secret_namespace: rbd-provisioner
+# rbd_provisioner_fs_type: ext4
+# rbd_provisioner_image_format: "2"
+# rbd_provisioner_image_features: layering
+# rbd_provisioner_storage_class: rbd
+# rbd_provisioner_reclaim_policy: Delete
+
+# Nginx ingress controller deployment
+ingress_nginx_enabled: false
+# ingress_nginx_host_network: false
+ingress_publish_status_address: ""
+# ingress_nginx_nodeselector:
+#   kubernetes.io/os: "linux"
+# ingress_nginx_tolerations:
+#   - key: "node-role.kubernetes.io/master"
+#     operator: "Equal"
+#     value: ""
+#     effect: "NoSchedule"
+# ingress_nginx_namespace: "ingress-nginx"
+# ingress_nginx_insecure_port: 80
+# ingress_nginx_secure_port: 443
+# ingress_nginx_configmap:
+#   map-hash-bucket-size: "128"
+#   ssl-protocols: "SSLv2"
+# ingress_nginx_configmap_tcp_services:
+#   9000: "default/example-go:8080"
+# ingress_nginx_configmap_udp_services:
+#   53: "kube-system/coredns:53"
+# ingress_nginx_extra_args:
+#   - --default-ssl-certificate=default/foo-tls
+
+# ambassador ingress controller deployment
+ingress_ambassador_enabled: false
+# ingress_ambassador_namespace: "ambassador"
+# ingress_ambassador_version: "*"
+
+# ALB ingress controller deployment
+ingress_alb_enabled: false
+# alb_ingress_aws_region: "us-east-1"
+# alb_ingress_restrict_scheme: "false"
+# Enables logging on all outbound requests sent to the AWS API.
+# If logging is desired, set to true.
+# alb_ingress_aws_debug: "false"
+
+# Cert manager deployment
+cert_manager_enabled: false
+# cert_manager_namespace: "cert-manager"
+
+# MetalLB deployment
+metallb_enabled: false
+# metallb_ip_range:
+#   - "10.5.0.50-10.5.0.99"
+# metallb_version: v0.9.3
+# metallb_protocol: "layer2"
+# metallb_port: "7472"
+# metallb_limits_cpu: "100m"
+# metallb_limits_mem: "100Mi"
+# metallb_additional_address_pools:
+#   kube_service_pool:
+#     ip_range:
+#       - "10.5.1.50-10.5.1.99"
+#     protocol: "layer2"
+#     auto_assign: false
+# metallb_protocol: "bgp"
+# metallb_peers:
+#   - peer_address: 192.0.2.1
+#     peer_asn: 64512
+#     my_asn: 4200000000
+#   - peer_address: 192.0.2.2
+#     peer_asn: 64513
+#     my_asn: 4200000000

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-cluster.yml
@@ -1,0 +1,314 @@
+---
+# Kubernetes configuration dirs and system namespace.
+# Those are where all the additional config stuff goes
+# the kubernetes normally puts in /srv/kubernetes.
+# This puts them in a sane location and namespace.
+# Editing those values will almost surely break something.
+kube_config_dir: /etc/kubernetes
+kube_script_dir: "{{ bin_dir }}/kubernetes-scripts"
+kube_manifest_dir: "{{ kube_config_dir }}/manifests"
+
+# This is where all the cert scripts and certs will be located
+kube_cert_dir: "{{ kube_config_dir }}/ssl"
+
+# This is where all of the bearer tokens will be stored
+kube_token_dir: "{{ kube_config_dir }}/tokens"
+
+# This is where to save basic auth file
+kube_users_dir: "{{ kube_config_dir }}/users"
+
+kube_api_anonymous_auth: true
+
+## Change this to use another Kubernetes version, e.g. a current beta release
+kube_version: v1.18.6
+
+# kubernetes image repo define
+kube_image_repo: "k8s.gcr.io"
+
+# Where the binaries will be downloaded.
+# Note: ensure that you've enough disk space (about 1G)
+local_release_dir: "/tmp/releases"
+# Random shifts for retrying failed ops like pushing/downloading
+retry_stagger: 5
+
+# This is the group that the cert creation scripts chgrp the
+# cert files to. Not really changeable...
+kube_cert_group: kube-cert
+
+# Cluster Loglevel configuration
+kube_log_level: 2
+
+# Directory where credentials will be stored
+credentials_dir: "{{ inventory_dir }}/credentials"
+
+# Users to create for basic auth in Kubernetes API via HTTP
+# Optionally add groups for user
+kube_api_pwd: "{{ lookup('password', credentials_dir + '/kube_user.creds length=15 chars=ascii_letters,digits') }}"
+kube_users:
+  kube:
+    pass: "{{kube_api_pwd}}"
+    role: admin
+    groups:
+      - system:masters
+
+## It is possible to activate / deactivate selected authentication methods (basic auth, static token auth)
+# kube_oidc_auth: false
+# kube_basic_auth: false
+# kube_token_auth: false
+
+
+## Variables for OpenID Connect Configuration https://kubernetes.io/docs/admin/authentication/
+## To use OpenID you have to deploy additional an OpenID Provider (e.g Dex, Keycloak, ...)
+
+# kube_oidc_url: https:// ...
+# kube_oidc_client_id: kubernetes
+## Optional settings for OIDC
+# kube_oidc_ca_file: "{{ kube_cert_dir }}/ca.pem"
+# kube_oidc_username_claim: sub
+# kube_oidc_username_prefix: oidc:
+# kube_oidc_groups_claim: groups
+# kube_oidc_groups_prefix: oidc:
+
+
+# Choose network plugin (cilium, calico, contiv, weave or flannel. Use cni for generic cni plugin)
+# Can also be set to 'cloud', which lets the cloud provider setup appropriate routing
+kube_network_plugin: calico
+
+# Setting multi_networking to true will install Multus: https://github.com/intel/multus-cni
+kube_network_plugin_multus: false
+
+# Kubernetes internal network for services, unused block of space.
+kube_service_addresses: 10.233.0.0/18
+
+# internal network. When used, it will assign IP
+# addresses from this range to individual pods.
+# This network must be unused in your network infrastructure!
+kube_pods_subnet: 10.233.64.0/18
+
+# internal network node size allocation (optional). This is the size allocated
+# to each node on your network.  With these defaults you should have
+# room for 4096 nodes with 254 pods per node.
+kube_network_node_prefix: 24
+
+# The port the API Server will be listening on.
+kube_apiserver_ip: "{{ kube_service_addresses|ipaddr('net')|ipaddr(1)|ipaddr('address') }}"
+kube_apiserver_port: 6443  # (https)
+# kube_apiserver_insecure_port: 8080  # (http)
+# Set to 0 to disable insecure port - Requires RBAC in authorization_modes and kube_api_anonymous_auth: true
+kube_apiserver_insecure_port: 0  # (disabled)
+
+# Kube-proxy proxyMode configuration.
+# Can be ipvs, iptables
+kube_proxy_mode: ipvs
+
+# configure arp_ignore and arp_announce to avoid answering ARP queries from kube-ipvs0 interface
+# must be set to true for MetalLB to work
+kube_proxy_strict_arp: false
+
+# A string slice of values which specify the addresses to use for NodePorts.
+# Values may be valid IP blocks (e.g. 1.2.3.0/24, 1.2.3.4/32).
+# The default empty string slice ([]) means to use all local addresses.
+# kube_proxy_nodeport_addresses_cidr is retained for legacy config
+kube_proxy_nodeport_addresses: >-
+  {%- if kube_proxy_nodeport_addresses_cidr is defined -%}
+  [{{ kube_proxy_nodeport_addresses_cidr }}]
+  {%- else -%}
+  []
+  {%- endif -%}
+
+# If non-empty, will use this string as identification instead of the actual hostname
+# kube_override_hostname: >-
+#   {%- if cloud_provider is defined and cloud_provider in [ 'aws' ] -%}
+#   {%- else -%}
+#   {{ inventory_hostname }}
+#   {%- endif -%}
+
+## Encrypting Secret Data at Rest (experimental)
+kube_encrypt_secret_data: false
+
+# DNS configuration.
+# Kubernetes cluster name, also will be used as DNS domain
+cluster_name: cluster.local
+# Subdomains of DNS domain to be resolved via /etc/resolv.conf for hostnet pods
+ndots: 2
+# Can be coredns, coredns_dual, manual or none
+dns_mode: coredns
+# Set manual server if using a custom cluster DNS server
+# manual_dns_server: 10.x.x.x
+# Enable nodelocal dns cache
+enable_nodelocaldns: true
+nodelocaldns_ip: 169.254.25.10
+nodelocaldns_health_port: 9254
+# nodelocaldns_external_zones:
+# - zones:
+#   - example.com
+#   - example.io:1053
+#   nameservers:
+#   - 1.1.1.1
+#   - 2.2.2.2
+#   cache: 5
+# - zones:
+#   - https://mycompany.local:4453
+#   nameservers:
+#   - 192.168.0.53
+#   cache: 0
+# Enable k8s_external plugin for CoreDNS
+enable_coredns_k8s_external: false
+coredns_k8s_external_zone: k8s_external.local
+# Enable endpoint_pod_names option for kubernetes plugin
+enable_coredns_k8s_endpoint_pod_names: false
+
+# Can be docker_dns, host_resolvconf or none
+resolvconf_mode: docker_dns
+# Deploy netchecker app to verify DNS resolve as an HTTP service
+deploy_netchecker: false
+# Ip address of the kubernetes skydns service
+skydns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(3)|ipaddr('address') }}"
+skydns_server_secondary: "{{ kube_service_addresses|ipaddr('net')|ipaddr(4)|ipaddr('address') }}"
+dns_domain: "{{ cluster_name }}"
+
+## Container runtime
+## docker for docker, crio for cri-o and containerd for containerd.
+container_manager: docker
+
+# Additional container runtimes
+kata_containers_enabled: false
+
+## Settings for containerd runtimes (only used when container_manager is set to containerd)
+#
+# Settings for default containerd runtime
+# containerd_default_runtime:
+#   type: io.containerd.runtime.v1.linux
+#   engine: ''
+#   root: ''
+#
+# Settings for additional runtimes for containerd configuration
+# containerd_runtimes:
+#   - name: ""
+#     type: ""
+#     engine: ""
+#     root: ""
+# Example for Kata Containers as additional runtime:
+# containerd_runtimes:
+#   - name: kata
+#     type: io.containerd.kata.v2
+#     engine: ""
+#     root: ""
+#
+# Settings for untrusted containerd runtime
+# containerd_untrusted_runtime_type: ''
+# containerd_untrusted_runtime_engine: ''
+# containerd_untrusted_runtime_root: ''
+
+## Settings for containerized control plane (kubelet/secrets)
+kubelet_deployment_type: host
+helm_deployment_type: host
+
+# Enable kubeadm experimental control plane
+kubeadm_control_plane: false
+kubeadm_certificate_key: "{{ lookup('password', credentials_dir + '/kubeadm_certificate_key.creds length=64 chars=hexdigits') | lower }}"
+
+# K8s image pull policy (imagePullPolicy)
+k8s_image_pull_policy: IfNotPresent
+
+# audit log for kubernetes
+kubernetes_audit: false
+
+# dynamic kubelet configuration
+dynamic_kubelet_configuration: false
+
+# define kubelet config dir for dynamic kubelet
+# kubelet_config_dir:
+default_kubelet_config_dir: "{{ kube_config_dir }}/dynamic_kubelet_dir"
+dynamic_kubelet_configuration_dir: "{{ kubelet_config_dir | default(default_kubelet_config_dir) }}"
+
+# pod security policy (RBAC must be enabled either by having 'RBAC' in authorization_modes or kubeadm enabled)
+podsecuritypolicy_enabled: false
+
+# Custom PodSecurityPolicySpec for restricted policy
+# podsecuritypolicy_restricted_spec: {}
+
+# Custom PodSecurityPolicySpec for privileged policy
+# podsecuritypolicy_privileged_spec: {}
+
+# Make a copy of kubeconfig on the host that runs Ansible in {{ inventory_dir }}/artifacts
+# kubeconfig_localhost: false
+# Download kubectl onto the host that runs Ansible in {{ bin_dir }}
+# kubectl_localhost: false
+
+# A comma separated list of levels of node allocatable enforcement to be enforced by kubelet.
+# Acceptable options are 'pods', 'system-reserved', 'kube-reserved' and ''. Default is "".
+# kubelet_enforce_node_allocatable: pods
+
+## Optionally reserve resources for OS system daemons.
+# system_reserved: true
+## Uncomment to override default values
+# system_memory_reserved: 512M
+# system_cpu_reserved: 500m
+## Reservation for master hosts
+# system_master_memory_reserved: 256M
+# system_master_cpu_reserved: 250m
+
+# An alternative flexvolume plugin directory
+# kubelet_flexvolumes_plugins_dir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+
+## Supplementary addresses that can be added in kubernetes ssl keys.
+## That can be useful for example to setup a keepalived virtual IP
+# supplementary_addresses_in_ssl_keys: [10.0.0.1, 10.0.0.2, 10.0.0.3]
+
+## Running on top of openstack vms with cinder enabled may lead to unschedulable pods due to NoVolumeZoneConflict restriction in kube-scheduler.
+## See https://github.com/kubernetes-sigs/kubespray/issues/2141
+## Set this variable to true to get rid of this issue
+volume_cross_zone_attachment: false
+## Add Persistent Volumes Storage Class for corresponding cloud provider (supported: in-tree OpenStack, Cinder CSI,
+## AWS EBS CSI, Azure Disk CSI, GCP Persistent Disk CSI)
+persistent_volumes_enabled: false
+
+## Container Engine Acceleration
+## Enable container acceleration feature, for example use gpu acceleration in containers
+# nvidia_accelerator_enabled: true
+## Nvidia GPU driver install. Install will by done by a (init) pod running as a daemonset.
+## Important: if you use Ubuntu then you should set in all.yml 'docker_storage_options: -s overlay2'
+## Array with nvida_gpu_nodes, leave empty or comment if you don't want to install drivers.
+## Labels and taints won't be set to nodes if they are not in the array.
+# nvidia_gpu_nodes:
+#   - kube-gpu-001
+# nvidia_driver_version: "384.111"
+## flavor can be tesla or gtx
+# nvidia_gpu_flavor: gtx
+## NVIDIA driver installer images. Change them if you have trouble accessing gcr.io.
+# nvidia_driver_install_centos_container: atzedevries/nvidia-centos-driver-installer:2
+# nvidia_driver_install_ubuntu_container: gcr.io/google-containers/ubuntu-nvidia-driver-installer@sha256:7df76a0f0a17294e86f691c81de6bbb7c04a1b4b3d4ea4e7e2cccdc42e1f6d63
+## NVIDIA GPU device plugin image.
+# nvidia_gpu_device_plugin_container: "k8s.gcr.io/nvidia-gpu-device-plugin@sha256:0842734032018be107fa2490c98156992911e3e1f2a21e059ff0105b07dd8e9e"
+
+## Support tls min version, Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+# tls_min_version: ""
+
+## Support tls cipher suites.
+# tls_cipher_suites: {}
+#   - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+#   - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+#   - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+#   - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+#   - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+#   - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+#   - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+#   - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+#   - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+#   - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+#   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+#   - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+#   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+#   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+#   - TLS_ECDHE_RSA_WITH_RC4_128_SHA
+#   - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+#   - TLS_RSA_WITH_AES_128_CBC_SHA
+#   - TLS_RSA_WITH_AES_128_CBC_SHA256
+#   - TLS_RSA_WITH_AES_128_GCM_SHA256
+#   - TLS_RSA_WITH_AES_256_CBC_SHA
+#   - TLS_RSA_WITH_AES_256_GCM_SHA384
+#   - TLS_RSA_WITH_RC4_128_SHA
+
+## Amount of time to retain events. (default 1h0m0s)
+event_ttl_duration: "1h0m0s"

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-calico.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-calico.yml
@@ -1,0 +1,74 @@
+# see roles/network_plugin/calico/defaults/main.yml
+
+## With calico it is possible to distributed routes with border routers of the datacenter.
+## Warning : enabling router peering will disable calico's default behavior ('node mesh').
+## The subnets of each nodes will be distributed by the datacenter router
+# peer_with_router: false
+
+# Enables Internet connectivity from containers
+# nat_outgoing: true
+
+# add default ippool name
+# calico_pool_name: "default-pool"
+
+# add default ippool blockSize (defaults kube_network_node_prefix)
+# calico_pool_blocksize: 24
+
+# add default ippool CIDR (must be inside kube_pods_subnet, defaults to kube_pods_subnet otherwise)
+# calico_pool_cidr: 1.2.3.4/5
+
+# Global as_num (/calico/bgp/v1/global/as_num)
+# global_as_num: "64512"
+
+# You can set MTU value here. If left undefined or empty, it will
+# not be specified in calico CNI config, so Calico will use built-in
+# defaults. The value should be a number, not a string.
+# calico_mtu: 1500
+
+# Configure the MTU to use for workload interfaces and tunnels.
+# - If Wireguard is enabled, set to your network MTU - 60
+# - Otherwise, if VXLAN or BPF mode is enabled, set to your network MTU - 50
+# - Otherwise, if IPIP is enabled, set to your network MTU - 20
+# - Otherwise, if not using any encapsulation, set to your network MTU.
+# calico_veth_mtu: 1440
+
+# Advertise Cluster IPs
+# calico_advertise_cluster_ips: true
+
+# Choose data store type for calico: "etcd" or "kdd" (kubernetes datastore)
+# calico_datastore: "etcd"
+
+# Choose Calico iptables backend: "Legacy", "Auto" or "NFT"
+# calico_iptables_backend: "Legacy"
+
+# Use typha (only with kdd)
+# typha_enabled: false
+
+# Generate TLS certs for secure typha<->calico-node communication
+# typha_secure: false
+
+# Scaling typha: 1 replica per 100 nodes is adequate
+# Number of typha replicas
+# typha_replicas: 1
+
+# Set max typha connections
+# typha_max_connections_lower_limit: 300
+
+# Set calico network backend: "bird", "vxlan" or "none"
+# bird enable BGP routing, required for ipip mode.
+# calico_network_backend: bird
+
+# IP in IP and VXLAN is mutualy exclusive modes.
+# set IP in IP encapsulation mode: "Always", "CrossSubnet", "Never"
+# calico_ipip_mode: 'Always'
+
+# set VXLAN encapsulation mode: "Always", "CrossSubnet", "Never"
+# calico_vxlan_mode: 'Never'
+
+# If you want to use non default IP_AUTODETECTION_METHOD for calico node set this option to one of:
+# * can-reach=DESTINATION
+# * interface=INTERFACE-REGEX
+# see https://docs.projectcalico.org/reference/node/configuration
+# calico_ip_auto_method: "interface=eth.*"
+# Choose the iptables insert mode for Calico: "Insert" or "Append".
+# calico_felix_chaininsertmode: Insert

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-canal.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-canal.yml
@@ -1,0 +1,10 @@
+# see roles/network_plugin/canal/defaults/main.yml
+
+# The interface used by canal for host <-> host communication.
+# If left blank, then the interface is choosing using the node's
+# default route.
+# canal_iface: ""
+
+# Whether or not to masquerade traffic to destinations not within
+# the pod network.
+# canal_masquerade: "true"

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-cilium.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-cilium.yml
@@ -1,0 +1,1 @@
+# see roles/network_plugin/cilium/defaults/main.yml

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-contiv.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-contiv.yml
@@ -1,0 +1,20 @@
+# see roles/network_plugin/contiv/defaults/main.yml
+
+# Forwarding mode: bridge or routing
+# contiv_fwd_mode: routing
+
+## With contiv, L3 BGP mode is possible by setting contiv_fwd_mode to "routing".
+## In this case, you may need to peer with an uplink
+## NB: The hostvars must contain a key "contiv" of which value is a dict containing "router_ip", "as"(defaults to contiv_global_as), "neighbor_as" (defaults to contiv_global_neighbor_as), "neighbor"
+# contiv_peer_with_uplink_leaf: false
+# contiv_global_as: "65002"
+# contiv_global_neighbor_as: "500"
+
+# Fabric mode: aci, aci-opflex or default
+# contiv_fabric_mode: default
+
+# Default netmode: vxlan or vlan
+# contiv_net_mode: vxlan
+
+# Dataplane interface
+# contiv_vlan_interface: ""

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-flannel.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-flannel.yml
@@ -1,0 +1,18 @@
+# see roles/network_plugin/flannel/defaults/main.yml
+
+## interface that should be used for flannel operations
+## This is actually an inventory cluster-level item
+# flannel_interface:
+
+## Select interface that should be used for flannel operations by regexp on Name or IP
+## This is actually an inventory cluster-level item
+## example: select interface with ip from net 10.0.0.0/23
+## single quote and escape backslashes
+# flannel_interface_regexp: '10\\.0\\.[0-2]\\.\\d{1,3}'
+
+# You can choose what type of flannel backend to use: 'vxlan' or 'host-gw'
+# for experimental backend
+# please refer to flannel's docs : https://github.com/coreos/flannel/blob/master/README.md
+# flannel_backend_type: "vxlan"
+# flannel_vxlan_vni: 1
+# flannel_vxlan_port: 8472

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-kube-router.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-kube-router.yml
@@ -1,0 +1,58 @@
+# See roles/network_plugin/kube-router//defaults/main.yml
+
+# Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP
+# kube_router_run_router: true
+
+# Enables Network Policy -- sets up iptables to provide ingress firewall for pods
+# kube_router_run_firewall: true
+
+# Enables Service Proxy -- sets up IPVS for Kubernetes Services
+# see docs/kube-router.md "Caveats" section
+# kube_router_run_service_proxy: false
+
+# Add Cluster IP of the service to the RIB so that it gets advertises to the BGP peers.
+# kube_router_advertise_cluster_ip: false
+
+# Add External IP of service to the RIB so that it gets advertised to the BGP peers.
+# kube_router_advertise_external_ip: false
+
+# Add LoadbBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.
+# kube_router_advertise_loadbalancer_ip: false
+
+# Adjust manifest of kube-router daemonset template with DSR needed changes
+# kube_router_enable_dsr: false
+
+# Array of arbitrary extra arguments to kube-router, see
+# https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md
+# kube_router_extra_args: []
+
+# ASN numbers of the BGP peer to which cluster nodes will advertise cluster ip and node's pod cidr.
+# kube_router_peer_router_asns: ~
+
+# The ip address of the external router to which all nodes will peer and advertise the cluster ip and pod cidr's.
+# kube_router_peer_router_ips: ~
+
+# The remote port of the external BGP to which all nodes will peer. If not set, default BGP port (179) will be used.
+# kube_router_peer_router_ports: ~
+
+# Setups node CNI to allow hairpin mode, requires node reboots, see
+# https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md#hairpin-mode
+# kube_router_support_hairpin_mode: false
+
+# Array of annotations for master
+# kube_router_annotations_master: []
+
+# Array of annotations for every node
+# kube_router_annotations_node: []
+
+# Array of common annotations for every node
+# kube_router_annotations_all: []
+
+# Enables scraping kube-router metrics with Prometheus
+# kube_router_enable_metrics: false
+
+# Path to serve Prometheus metrics on
+# kube_router_metrics_path: /metrics
+
+# Prometheus metrics port to use
+# kube_router_metrics_port: 9255

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-macvlan.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-macvlan.yml
@@ -1,0 +1,6 @@
+---
+# private interface, on a l2-network
+macvlan_interface: "eth1"
+
+# Enable nat in default gateway network interface
+enable_nat_default_gateway: true

--- a/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-weave.yml
+++ b/kubernetes-production-clusters/inventory/my-cluster/group_vars/k8s-cluster/k8s-net-weave.yml
@@ -1,0 +1,58 @@
+# see roles/network_plugin/weave/defaults/main.yml
+
+# Weave's network password for encryption, if null then no network encryption.
+# weave_password: ~
+
+# If set to 1, disable checking for new Weave Net versions (default is blank,
+# i.e. check is enabled)
+# weave_checkpoint_disable: false
+
+# Soft limit on the number of connections between peers. Defaults to 100.
+# weave_conn_limit: 100
+
+# Weave Net defaults to enabling hairpin on the bridge side of the veth pair
+# for containers attached. If you need to disable hairpin, e.g. your kernel is
+# one of those that can panic if hairpin is enabled, then you can disable it by
+# setting `HAIRPIN_MODE=false`.
+# weave_hairpin_mode: true
+
+# The range of IP addresses used by Weave Net and the subnet they are placed in
+# (CIDR format; default 10.32.0.0/12)
+# weave_ipalloc_range: "{{ kube_pods_subnet }}"
+
+# Set to 0 to disable Network Policy Controller (default is on)
+# weave_expect_npc: "{{ enable_network_policy }}"
+
+# List of addresses of peers in the Kubernetes cluster (default is to fetch the
+# list from the api-server)
+# weave_kube_peers: ~
+
+# Set the initialization mode of the IP Address Manager (defaults to consensus
+# amongst the KUBE_PEERS)
+# weave_ipalloc_init: ~
+
+# Set the IP address used as a gateway from the Weave network to the host
+# network - this is useful if you are configuring the addon as a static pod.
+# weave_expose_ip: ~
+
+# Address and port that the Weave Net daemon will serve Prometheus-style
+# metrics on (defaults to 0.0.0.0:6782)
+# weave_metrics_addr: ~
+
+# Address and port that the Weave Net daemon will serve status requests on
+# (defaults to disabled)
+# weave_status_addr: ~
+
+# Weave Net defaults to 1376 bytes, but you can set a smaller size if your
+# underlying network has a tighter limit, or set a larger size for better
+# performance if your network supports jumbo frames (e.g. 8916)
+# weave_mtu: 1376
+
+# Set to 1 to preserve the client source IP address when accessing Service
+# annotated with `service.spec.externalTrafficPolicy=Local`. The feature works
+# only with Weave IPAM (default).
+# weave_no_masq_local: true
+
+# Extra variables that passing to launch.sh, useful for enabling seed mode, see
+# https://www.weave.works/docs/net/latest/tasks/ipam/ipam/
+# weave_extra_args: ~

--- a/kubernetes-production-clusters/inventory/my-cluster/inventory-3-2.ini
+++ b/kubernetes-production-clusters/inventory/my-cluster/inventory-3-2.ini
@@ -1,0 +1,24 @@
+[all]
+node1 ansible_host=34.70.42.24 etcd_member_name=etcd1
+node2 ansible_host=35.225.27.69 etcd_member_name=etcd2
+node3 ansible_host=35.193.116.12 etcd_member_name=etcd3
+node4 ansible_host=35.236.156.71
+node5 ansible_host=35.234.35.138
+
+[kube-master]
+node1
+node2
+node3
+
+[etcd]
+node1
+node2
+node3
+
+[kube-node]
+node4
+node5
+
+[k8s-cluster:children]
+kube-master
+kube-node

--- a/kubernetes-production-clusters/inventory/my-cluster/inventory.ini
+++ b/kubernetes-production-clusters/inventory/my-cluster/inventory.ini
@@ -1,0 +1,20 @@
+[all]
+node1 ansible_host=104.154.48.104 etcd_member_name=etcd1
+node2 ansible_host=34.70.42.24
+node3 ansible_host=35.225.27.69
+node4 ansible_host=35.193.116.12
+
+[kube-master]
+node1
+
+[etcd]
+node1
+
+[kube-node]
+node2
+node3
+node4
+
+[k8s-cluster:children]
+kube-master
+kube-node


### PR DESCRIPTION
# Выполнено ДЗ №24

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:

Создаем инстансы в GCE

```bash
% gcloud compute images list | grep ubuntu
NAME                                                  PROJECT              FAMILY                            DEPRECATED  STATUS
ubuntu-1604-xenial-v20200807                          ubuntu-os-cloud      ubuntu-1604-lts                               READY
ubuntu-1804-bionic-v20200807                          ubuntu-os-cloud      ubuntu-1804-lts                               READY
ubuntu-2004-focal-v20200810                           ubuntu-os-cloud      ubuntu-2004-lts                               READY
ubuntu-minimal-1604-xenial-v20200807                  ubuntu-os-cloud      ubuntu-minimal-1604-lts                       READY
ubuntu-minimal-1804-bionic-v20200806                  ubuntu-os-cloud      ubuntu-minimal-1804-lts                       READY
ubuntu-minimal-2004-focal-v20200729                   ubuntu-os-cloud      ubuntu-minimal-2004-lts                       READY


% gcloud compute instances create kube-master --zone us-central1-c --machine-type=n1-standard-2 --image-project ubuntu-os-cloud --image-family ubuntu-minimal-1804-lts
NAME         ZONE           MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP  EXTERNAL_IP    STATUS
kube-master  us-central1-c  n1-standard-2               10.128.0.52  34.121.113.99  RUNNING

% gcloud compute instances create kube-worker-1 kube-worker-2 kube-worker-3 --zone us-central1-c --machine-type=n1-standard-1 --image-project ubuntu-os-cloud --image-family ubuntu-minimal-1804-lts
NAME           ZONE           MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP  EXTERNAL_IP    STATUS
kube-worker-1  us-central1-c  n1-standard-1               10.128.0.55  34.121.12.241  RUNNING
kube-worker-2  us-central1-c  n1-standard-1               10.128.0.53  34.121.209.30  RUNNING
kube-worker-3  us-central1-c  n1-standard-1               10.128.0.54  34.121.64.155  RUNNING
```

На всех инстансах по очереди проделываем след действия:

## Подготовка инстансов

0. Авторизуемся на машине

```bash
% gcloud beta compute ssh root@kube-master --zone us-central1-c
```

1. Отключаем swap

```bash
% root@kube-master:~# swapoff -a
```

2. Включаем маршрутизацию

```bash
root@kube-master:~# cat > /etc/sysctl.d/99-kubernetes-cri.conf <<EOF
net.bridge.bridge-nf-call-iptables = 1
net.ipv4.ip_forward = 1
net.bridge.bridge-nf-call-ip6tables = 1
EOF
root@kube-master:~# sysctl --system
```

2. Установка Docker

```bash
root@kube-master:~# apt-get update && apt-get install -y apt-transport-https ca-certificates curl software-properties-common gnupg2
root@kube-master:~# curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
root@kube-master:~# add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
root@kube-master:~# apt-get update && apt-get install -y containerd.io=1.2.13-1 docker-ce=5:19.03.8~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.8~3-0~ubuntu-$(lsb_release -cs)

# Setup daemon.
root@kube-master:~# cat > /etc/docker/daemon.json <<EOF
{
    "exec-opts": ["native.cgroupdriver=systemd"],
    "log-driver": "json-file",
    "log-opts": {
        "max-size": "100m"
    },
    "storage-driver": "overlay2"
}
EOF
root@kube-master:~# mkdir -p /etc/systemd/system/docker.service.d

# Restart docker.
root@kube-master:~# systemctl daemon-reload
root@kube-master:~# systemctl restart docker
```

3. Установка kubeadm, kubelet & kubectl

```bash
root@kube-master:~# apt-get update && apt-get install -y apt-transport-https curl
root@kube-master:~# curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
root@kube-master:~# cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
deb https://apt.kubernetes.io/ kubernetes-xenial main
EOF
root@kube-master:~# apt-get update
root@kube-master:~# apt-get install -y kubelet=1.17.4-00 kubeadm=1.17.4-00 kubectl=1.17.4-00
```

## Создание кластера

Настроим `kube-master` как мастер

```bash
% gcloud beta compute ssh root@kube-master --zone us-central1-c
root@kube-master:~# kubeadm init --pod-network-cidr=192.168.0.0/24

Your Kubernetes control-plane has initialized successfully!

To start using your cluster, you need to run the following as a regular user:

  mkdir -p $HOME/.kube
  sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
  sudo chown $(id -u):$(id -g) $HOME/.kube/config

You should now deploy a pod network to the cluster.
Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
  https://kubernetes.io/docs/concepts/cluster-administration/addons/

Then you can join any number of worker nodes by running the following on each as root:

kubeadm join 10.128.0.52:6443 --token pxu53d.kenwt1aee7t4igpk \
    --discovery-token-ca-cert-hash sha256:1983f95528a305645caaee35fad5da37fc4bc9f680b11b0a969bbda4fad7a48d 
```

Настроим `kubectl`

```bash
root@kube-master:~# mkdir -p $HOME/.kube
root@kube-master:~# sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
root@kube-master:~# sudo chown $(id -u):$(id -g) $HOME/.kube/config

# Check.
root@kube-master:~# kubectl get nodes
NAME          STATUS     ROLES    AGE     VERSION
kube-master   NotReady   master   2m23s   v1.17.4

root@kube-master:~# kubectl get pods -A
NAMESPACE     NAME                                       READY   STATUS     RESTARTS   AGE
kube-system   coredns-6955765f44-h6grq                   0/1     Pending    0          3m44s
kube-system   coredns-6955765f44-sslbm                   0/1     Pending    0          3m44s
kube-system   etcd-kube-master                           1/1     Running    0          3m59s
kube-system   kube-apiserver-kube-master                 1/1     Running    0          3m59s
kube-system   kube-controller-manager-kube-master        1/1     Running    0          3m59s
kube-system   kube-proxy-qmdpb                           1/1     Running    0          3m44s
kube-system   kube-scheduler-kube-master                 1/1     Running    0          3m59s
```

Установим сетевой плагин

```bash
root@kube-master:~# kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml
```

Подключим worker-ноды

```bash
root@kube-master:~# kubeadm token list
TOKEN                     TTL         EXPIRES                USAGES                   DESCRIPTION                                                EXTRA GROUPS
pxu53d.kenwt1aee7t4igpk   23h         2020-08-16T06:43:36Z   authentication,signing   The default bootstrap token generated by 'kubeadm init'.   system:bootstrappers:kubeadm:default-node-token

root@kube-master:~# openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //'
1983f95528a305645caaee35fad5da37fc4bc9f680b11b0a969bbda4fad7a48d

% gcloud beta compute ssh root@kube-worker-1 --zone us-central1-c -- kubeadm join 10.128.0.52:6443 --token pxu53d.kenwt1aee7t4igpk --discovery-token-ca-cert-hash sha256:1983f95528a305645caaee35fad5da37fc4bc9f680b11b0a969bbda4fad7a48d
% gcloud beta compute ssh root@kube-worker-2 --zone us-central1-c -- kubeadm join 10.128.0.52:6443 --token pxu53d.kenwt1aee7t4igpk --discovery-token-ca-cert-hash sha256:1983f95528a305645caaee35fad5da37fc4bc9f680b11b0a969bbda4fad7a48d
% gcloud beta compute ssh root@kube-worker-3 --zone us-central1-c -- kubeadm join 10.128.0.52:6443 --token pxu53d.kenwt1aee7t4igpk --discovery-token-ca-cert-hash sha256:1983f95528a305645caaee35fad5da37fc4bc9f680b11b0a969bbda4fad7a48d

% gcloud beta compute ssh root@kube-master --zone us-central1-c -- kubectl get nodes -o wide
NAME            STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
kube-master     Ready    master   10m    v1.17.4   10.128.0.52   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-1   Ready    <none>   3m6s   v1.17.4   10.128.0.55   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-2   Ready    <none>   45s    v1.17.4   10.128.0.53   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-3   Ready    <none>   31s    v1.17.4   10.128.0.54   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
```

Проверяем

```bash
% gcloud beta compute ssh root@kube-master --zone us-central1-c

root@kube-master:~# kubectl apply -f /tmp/nginx.yaml
root@kube-master:~# kubectl get all
NAME                                   READY   STATUS    RESTARTS   AGE
pod/nginx-deployment-d78cc675c-82hqw   1/1     Running   0          15s
pod/nginx-deployment-d78cc675c-gg7d2   1/1     Running   0          15s
pod/nginx-deployment-d78cc675c-p7stp   1/1     Running   0          15s
pod/nginx-deployment-d78cc675c-pzwnh   1/1     Running   0          15s

NAME                 TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
service/kubernetes   ClusterIP   10.96.0.1    <none>        443/TCP   16m

NAME                               READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/nginx-deployment   4/4     4            4           15s

NAME                                         DESIRED   CURRENT   READY   AGE
replicaset.apps/nginx-deployment-d78cc675c   4         4         4       15s
```

## Обновление кластера

### Обновление мастера

Обновляем сначала мастер. Отставание мастера от нод не допустимо

```bash
% gcloud beta compute ssh root@kube-master --zone us-central1-c -- apt-get update
% gcloud beta compute ssh root@kube-master --zone us-central1-c -- apt-get install -y kubeadm=1.18.0-00 kubelet=1.18.0-00 kubectl=1.18.0-00

% gcloud beta compute ssh root@kube-master --zone us-central1-c --  kubectl get nodes -o wide
NAME            STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
kube-master     Ready    master   20m   v1.18.0   10.128.0.52   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-1   Ready    <none>   12m   v1.17.4   10.128.0.55   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-2   Ready    <none>   10m   v1.17.4   10.128.0.53   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-3   Ready    <none>   10m   v1.17.4   10.128.0.54   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
```

Обновим остальные компоненты

```bash
root@kube-master:~# kubeadm upgrade plan
...
Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
COMPONENT   CURRENT       AVAILABLE
Kubelet     3 x v1.17.4   v1.18.8
            1 x v1.18.0   v1.18.8

Upgrade to the latest stable version:

COMPONENT            CURRENT    AVAILABLE
API Server           v1.17.11   v1.18.8
Controller Manager   v1.17.11   v1.18.8
Scheduler            v1.17.11   v1.18.8
Kube Proxy           v1.17.11   v1.18.8
CoreDNS              1.6.5      1.6.7
Etcd                 3.4.3      3.4.3-0
...

root@kube-master:~# kubeadm upgrade apply v1.18.0
...
[upgrade/successful] SUCCESS! Your cluster was upgraded to "v1.18.0". Enjoy!
...

# kubeadm
root@kube-master:~# kubeadm version
kubeadm version: &version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"9e991415386e4cf155a24b1da15becaa390438d8", GitTreeState:"clean", BuildDate:"2020-03-25T14:56:30Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}

# kubelet
root@kube-master:~# kubelet --version
Kubernetes v1.18.0

# kubectl
root@kube-master:~# kubectl version
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"9e991415386e4cf155a24b1da15becaa390438d8", GitTreeState:"clean", BuildDate:"2020-03-25T14:58:59Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"9e991415386e4cf155a24b1da15becaa390438d8", GitTreeState:"clean", BuildDate:"2020-03-25T14:50:46Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}

# kube-apiserver
root@kube-master:~# kubectl -n kube-system get pods -l component=kube-apiserver -o jsonpath='{.items[*].spec.containers[*].image}{"\n"}'
k8s.gcr.io/kube-apiserver:v1.18.0
```

### Обновление `kube-worker-1`

Выводим ноду из планирования

```bash
root@kube-master:~# kubectl drain kube-worker-1 --ignore-daemonsets
node/kube-worker-1 cordoned
WARNING: ignoring DaemonSet-managed Pods: kube-system/calico-node-mtwcc, kube-system/kube-proxy-759cx
evicting pod default/nginx-deployment-d78cc675c-p7stp
evicting pod kube-system/coredns-66bff467f8-x9js5
pod/coredns-66bff467f8-x9js5 evicted
pod/nginx-deployment-d78cc675c-p7stp evicted
node/kube-worker-1 evicted

root@kube-master:~# kubectl get nodes -o wide
NAME            STATUS                     ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
kube-master     Ready                      master   54m   v1.18.0   10.128.0.52   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-1   Ready,SchedulingDisabled   <none>   47m   v1.17.4   10.128.0.55   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-2   Ready                      <none>   45m   v1.17.4   10.128.0.53   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-3   Ready                      <none>   44m   v1.17.4   10.128.0.54   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
```

Обновляем worker-ноду

```bash
% gcloud beta compute ssh root@kube-worker-1 --zone us-central1-c -- apt-get install -y kubelet=1.18.0-00 kubeadm=1.18.0-00
% gcloud beta compute ssh root@kube-worker-1 --zone us-central1-c -- systemctl restart kubelet
% gcloud beta compute ssh root@kube-master --zone us-central1-c -- kubectl get nodes -o wide
NAME            STATUS                     ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
kube-master     Ready                      master   57m   v1.18.0   10.128.0.52   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-1   Ready,SchedulingDisabled   <none>   50m   v1.18.0   10.128.0.55   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-2   Ready                      <none>   47m   v1.17.4   10.128.0.53   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-3   Ready                      <none>   47m   v1.17.4   10.128.0.54   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
```

Возвращаем ноду в планирование

```bash
% gcloud beta compute ssh root@kube-master --zone us-central1-c -- kubectl uncordon kube-worker-1
node/kube-worker-1 uncordoned

% gcloud beta compute ssh root@kube-master --zone us-central1-c -- kubectl get nodes -o wide
NAME            STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
kube-master     Ready    master   59m   v1.18.0   10.128.0.52   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-1   Ready    <none>   51m   v1.18.0   10.128.0.55   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-2   Ready    <none>   49m   v1.17.4   10.128.0.53   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-3   Ready    <none>   49m   v1.17.4   10.128.0.54   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
```

### Обновляем `kube-worker-1` & `kube-worker-2` через `kubeadm`

Выводим ноды из планирования

```bash
root@kube-master:~# kubectl drain kube-worker-2 --ignore-daemonsets
root@kube-master:~# kubectl drain kube-worker-3 --ignore-daemonsets

root@kube-master:~# kubectl get nodes -o wide
NAME            STATUS                     ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
kube-master     Ready                      master   69m   v1.18.0   10.128.0.52   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-1   Ready                      <none>   61m   v1.18.0   10.128.0.55   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-2   Ready,SchedulingDisabled   <none>   59m   v1.17.4   10.128.0.53   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-3   Ready,SchedulingDisabled   <none>   59m   v1.17.4   10.128.0.54   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
```

Обновляем

```bash
# Upgrade kube-worker-2
root@kube-worker-2:~# kubeadm upgrade node

root@kube-worker-2:~# apt-get install -y kubelet=1.18.0-00
root@kube-worker-2:~# systemctl daemon-reload
root@kube-worker-2:~# systemctl restart kubelet

# Upgrade kube-worker-3
root@kube-worker-3:~# kubeadm upgrade node

root@kube-worker-3:~# apt-get install -y kubelet=1.18.0-00
root@kube-worker-3:~# systemctl daemon-reload
root@kube-worker-3:~# systemctl restart kubelet
```

Проверяем и возвращаем планирование

```bash
root@kube-master:~# kubectl get nodes -o wide
NAME            STATUS                     ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
kube-master     Ready                      master   96m   v1.18.0   10.128.0.52   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-1   Ready                      <none>   89m   v1.18.0   10.128.0.55   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-2   Ready,SchedulingDisabled   <none>   86m   v1.18.0   10.128.0.53   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-3   Ready,SchedulingDisabled   <none>   86m   v1.18.0   10.128.0.54   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8

root@kube-master:~# kubectl uncordon kube-worker-2
node/kube-worker-2 uncordoned

root@kube-master:~# kubectl uncordon kube-worker-3
node/kube-worker-3 uncordoned

root@kube-master:~# kubectl get nodes -o wide
NAME            STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
kube-master     Ready    master   97m   v1.18.0   10.128.0.52   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-1   Ready    <none>   90m   v1.18.0   10.128.0.55   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-2   Ready    <none>   87m   v1.18.0   10.128.0.53   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
kube-worker-3   Ready    <none>   87m   v1.18.0   10.128.0.54   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.8
```

## Автоматическое развертывание кластера

### Подготовка

Подготовка `Kubespray`

```bash
% git submodule add git@github.com:kubernetes-sigs/kubespray.git
% pip install -r requirements.txt
```

Опишем конфиг `Kubespray`

```bash
% mkdir -p kubernetes-production-clusters/inventory/my-cluster
% cp -rfp kubernetes-production-clusters/kubespray/inventory/sample/ kubernetes-production-clusters/inventory/my-cluster/
% cat kubernetes-production-clusters/inventory/my-cluster/inventory.ini
[all]
node1 ansible_host=104.154.48.104 etcd_member_name=etcd1
node2 ansible_host=34.70.42.24
node3 ansible_host=35.225.27.69
node4 ansible_host=35.193.116.12

[kube-master]
node1

[etcd]
node1

[kube-node]
node2
node3
node4

[k8s-cluster:children]
kube-master
kube-node
```

### Установка кластера

```bash
% cd kubernetes-production-clusters
% ansible-playbook -i inventory/my-cluster/inventory.ini --become --become-user=root --user=root --key-file=~/.ssh/gce_without_prompt kubespray/cluster.yml

...
PLAY RECAP *******************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
node1                      : ok=585  changed=128  unreachable=0    failed=0    skipped=1116 rescued=0    ignored=0
node2                      : ok=360  changed=83   unreachable=0    failed=0    skipped=578  rescued=0    ignored=0
node3                      : ok=360  changed=83   unreachable=0    failed=0    skipped=577  rescued=0    ignored=0
node4                      : ok=360  changed=83   unreachable=0    failed=0    skipped=577  rescued=0    ignored=0
```

Проверяем

```bash
% gcloud beta compute ssh root@kube-master --zone us-central1-c -- kubectl get nodes -o wide
NAME    STATUS   ROLES    AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
node1   Ready    master   12m     v1.18.6   10.128.0.60   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.12
node2   Ready    <none>   8m36s   v1.18.6   10.128.0.61   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.12
node3   Ready    <none>   8m36s   v1.18.6   10.128.0.63   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.12
node4   Ready    <none>   8m36s   v1.18.6   10.128.0.62   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.12
```

## (*) Автоматическое развертывание кластера 3 мастера / 2 воркера

```bash
% cd kubernetes-production-clusters
% ansible-playbook -i inventory/my-cluster/inventory-3-2.ini --become --become-user=root --user=root --key-file=~/.ssh/gce_without_prompt kubespray/cluster.yml

PLAY RECAP *******************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
node1                      : ok=582  changed=121  unreachable=0    failed=0    skipped=1119 rescued=0    ignored=0
node2                      : ok=509  changed=111  unreachable=0    failed=0    skipped=956  rescued=0    ignored=0
node3                      : ok=511  changed=112  unreachable=0    failed=0    skipped=954  rescued=0    ignored=0
node4                      : ok=359  changed=78   unreachable=0    failed=0    skipped=579  rescued=0    ignored=0
node5                      : ok=359  changed=78   unreachable=0    failed=0    skipped=578  rescued=0    ignored=0
```

Проверяем

```bash
% gcloud beta compute ssh root@kube-master-1 --zone us-central1-c -- kubectl get nodes -o wide
NAME    STATUS   ROLES    AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
node1   Ready    master   29m   v1.18.6   10.128.15.198   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.12
node2   Ready    master   26m   v1.18.6   10.128.15.197   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.12
node3   Ready    master   26m   v1.18.6   10.128.15.196   <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.12
node4   Ready    <none>   22m   v1.18.6   10.140.0.4      <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.12
node5   Ready    <none>   22m   v1.18.6   10.140.0.5      <none>        Ubuntu 18.04.4 LTS   5.3.0-1032-gcp   docker://19.3.12
```



## PR checklist:
 - [x] Выставлен label с темой домашнего задания